### PR TITLE
Typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
 	  <tr>
 	    <td>metadataParser</td>
 	    <td>Function</td>
-	    <td>Function that will parse DOI content negotation response. Must return
+	    <td>Function that will parse DOI content negotiation response. Must return
 	      a map with keys <code>authors</code>, <code>title</code>, <code>licenses</code> and <code>resources</code>. Defaults to a function that parses CSL JSON.</td>
 	  </tr>
 	  <tr>


### PR DESCRIPTION
This typo is also present in https://citation.crosscite.org/docs.html#sec-4 - but I can't find the source for that page.